### PR TITLE
Target production URL & AASP settings

### DIFF
--- a/js/myschoolsask.com.js
+++ b/js/myschoolsask.com.js
@@ -219,6 +219,17 @@ function hideYOGFields(settings) {
 	}
 }
 
+function setAASPDefault(settings) {
+	if (
+		(document.title.toLowerCase().includes("log on"))
+		) {
+		logMsg("Setting AASP drop down");
+
+		// Set the AASP dropdown to the stored division name
+		$("select[name='districtId']").val(settings.sAASPDivNum)
+	}
+}
+
 function disableTimeout(settings) {
 	// We may need to periodically call tickleServer(); (from mss common.js) to keep the server up to date
 
@@ -290,7 +301,7 @@ function overrideTimeout(settings) {
 
 function showItWorksBanner(settings) {
 	logMsg("It works!");
-	$("body").before("<div style=\"font-size: 8pt; margin: 0; padding: 0; width: 100%; background-color: yellow; color: black;text-align: center;font-family: sans-serif;\">MySchoolSask Enhancement Suite is able to modify the contents of this page.</div>");
+	$("body").before("<div style=\"z-index:1; position: absolute; font-size: 8pt; margin: 0; padding: 0; width: 100%; background-color: yellow; color: black;text-align: center;font-family: sans-serif;\">MySchoolSask Enhancement Suite is able to modify the contents of this page.</div>");
 }
 
 function enableShiftClickCheckboxes(settings) {
@@ -306,7 +317,12 @@ function enableShiftClickCheckboxes(settings) {
 }
 
 function onSettingsLoaded(settings) {
-	// Don't load any of this stuff on the login screen
+	
+	// Check if we should show the "It Works" banner
+	if (settings.lShowItWorksBanner == true) {
+		showItWorksBanner(settings);
+	}
+
 	if (!document.title.toLowerCase().includes("log on")) {
 
 		// Check if we should adjust the timeout
@@ -314,11 +330,6 @@ function onSettingsLoaded(settings) {
 			disableTimeout(settings);
 		} else if (settings.sTimeoutOverrideMode == "override") {
 			overrideTimeout(settings);
-		}
-
-		// Check if we should show the "It Works" banner
-		if (settings.lShowItWorksBanner == true) {
-			showItWorksBanner(settings);
 		}
 
 		if (settings.lHideYOGRow == true) {
@@ -333,11 +344,18 @@ function onSettingsLoaded(settings) {
 	 	// Check if we should enable shift+clicking checkboxes
 	 	if (settings.lEnableCheckboxMultiSelect == true) {
 	 		enableShiftClickCheckboxes(settings);
-	 	}
-
-
+		 }
+		 
  	} else {
- 		logMsg("Supressing all enhancements on login screen");
+
+		// Check if we should set the AASP default
+		if (settings.lSetAASPDropdown == true) {
+			setAASPDefault(settings);
+			// This will automatically click the AASP button but puts the user in a loop when
+			// they try to log out.
+			//$("a[href='javascript:gotoSSO()']")[0].click();
+		}
+		
  	}
 }
 

--- a/js/options_page.js
+++ b/js/options_page.js
@@ -97,6 +97,18 @@ $("#chkHideYearofGraduationFields").on('change', function() {
   });
 });
 
+$("#chkEnableAASPSelect").on('change', function() {
+  chrome.storage.sync.set({
+    lSetAASPDropdown: document.querySelector("#chkEnableAASPSelect").checked
+  });
+});
+
+$("#txtAASPSchoolDiv").on('input', function() {
+  chrome.storage.sync.set({
+    sAASPDivNum: document.querySelector("#txtAASPSchoolDiv").value
+  });
+});
+
 $("#chkShowDebugOptions").on('change', function() {
   var lShowDebugOptions = document.querySelector("#chkShowDebugOptions").checked || false;
   if (lShowDebugOptions == true) {
@@ -126,6 +138,8 @@ $("#btnResetSettingsToDefault").on('click', function() {
         lShowYOGGradeDropdowns: true,
         lHideYOGRow: false,
         lEnableCheckboxMultiSelect: true,
+        lSetAASPDropdown: false,
+        sAASPDivNum: ""
   });
   location.reload();
 });
@@ -178,6 +192,20 @@ function checkDefaultSettings(settings) {
         lEnableCheckboxMultiSelect: true
       });
   }
+
+  if (settings.lSetAASPDropdown == null) {
+    logMsg("Defaulting new setting \"lSetAASPDropdown\" to false");
+    chrome.storage.sync.set({
+        lSetAASPDropdown: false
+      });
+  }
+
+  if (settings.sAASPDivNum == null) {
+    logMsg("Defaulting new setting \"sAASPDivNum\" to ''");
+    chrome.storage.sync.set({
+        sAASPDivNum: ""
+      });
+  }
 }
 
 /// Visually updates the fields on the options page to match the stored settings, or the defauls
@@ -195,6 +223,10 @@ function onSyncSettingsLoaded(settings) {
   document.querySelector("#chkShowGradeDropdownOnRegWizard").checked = (settings.lShowYOGGradeDropdowns || false);
   document.querySelector("#chkHideYearofGraduationFields").checked = (settings.lHideYOGRow || false);
   document.querySelector("#chkHideYearofGraduationFields").disabled = !settings.lShowYOGGradeDropdowns;
+
+  // AASP 
+  document.querySelector("#chkEnableAASPSelect").checked = (settings.lSetAASPDropdown || false);
+  document.querySelector("#txtAASPSchoolDiv").value = (settings.sAASPDivNum || "");
 
   // Session timeouts
   switch(settings["sTimeoutOverrideMode"]) {

--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -11,7 +11,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://*.myschoolsask.com/aspen/*"],
+      "matches": ["*://*.myschoolsask.com/aspen/*", "*://myschoolsask.ca/aspen/*"],
       "js": ["/thirdparty/jquery-3.3.1.min.js", "/js/myschoolsask.com.js"]
     }
   ],

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -10,7 +10,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://*.myschoolsask.com/aspen/*"],
+      "matches": ["*://*.myschoolsask.com/aspen/*", "*://myschoolsask.ca/aspen/*"],
       "js": ["/thirdparty/jquery-3.3.1.min.js", "/js/myschoolsask.com.js"]
     }
   ],

--- a/pages/options.html
+++ b/pages/options.html
@@ -185,6 +185,17 @@
         </p>
         </div>
 
+        <div class="optionsSection">
+          <h2>AASP</h2>
+          <p>
+            Automatically choose the specified school division from the AASP dropdown list.  Enter the 3 digit school division number with a leading zero if necessary
+          </p> 
+          <p>
+            <input type="checkbox" id="chkEnableAASPSelect" > Enable default AASP selection <br /><br />
+            School Division #: <input type="text" id="txtAASPSchoolDiv">
+          </p>
+          </div>
+
         <div class="optionsSection" style="font-size: 75%">
         <h2>Testing and Debugging Options</h2>
           <input type="checkbox" id="chkShowDebugOptions" > Show testing and debug options


### PR DESCRIPTION
Hi Mark,

I hope you don't mind a contribution.  
The first commit updates the manifests so that they target the .ca domain.  The second adds some AASP settings.  Because we plan to use AASP I thought it would be helpful if the drop down was automatically populated with our school info.  I've added an option to the options page for users to put their SD number in and have it automatically select their school.  I did my best to follow the conventions and style you are already using in the code.

I did not bump the version so you might want to do that if you accept the PR.

Tyler